### PR TITLE
Fix exports flag

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -53,7 +53,11 @@ async function main() {
     return
   }
 
-  if (inputPackages.length > 0) {
+  if (inputPackages.length > 0 && inputExports.length > 0) {
+    spinner = ora().start(
+      `Search for packages: ${inputPackages}. With exports: ${inputExports}`
+    )
+  } else if (inputPackages.length > 0) {
     spinner = ora().start(`Search for packages: ${inputPackages}`)
   } else if (inputExports.length > 0) {
     spinner = ora().start(`Search for exports: ${inputExports}`)
@@ -82,8 +86,7 @@ async function main() {
 
     if (packages.length > 0) {
       if (cli.flags.exports) {
-        const result = packages.map(pack => pack.toPlainObject())
-        // Const result = packages.map(pack => pack.exportReport(inputExports)
+        const result = packages.map(pack => pack.exportReport(inputExports))
         console.log(toJSON(result))
       } else {
         const result = packages.map(pack => pack.toPlainObject())


### PR DESCRIPTION
For some reason I forgot to support the `--packages` + `--exports` in the cli tool.

This works for now:

```
$ dependency-report './client/**/*.js' --packages=evergreen-ui --exports=SideSheet,Popover,CornerDialog,RadioGroup
```