### PR TITLE
Updates installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ _Note: only supports ES2015 `import` statements (not CommonJS `require` calls)._
 ## Install
 
 ```
-yarn add dependency-report
+yarn add @segment/dependency-report
 # or
-npm install dependency-report
+npm install @segment/dependency-report
 ```
 
 ## CLI Usage


### PR DESCRIPTION
Updates installation instructions to use `@segment/` since `dependency-report` isn't available on NPM