### PR TITLE
Update example of node usage to use expected input

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,6 @@ $ dependency-report './client/**/*.js' --packages=evergreen-ui --exports=SideShe
 const DependencyReport = require('@segment/dependency-report')
 
 const report = new DependencyReport({
-  files: '**/*.js'
+  files: ['**/*.js']
 })
 ```


### PR DESCRIPTION
The `files` property is supposed to be an array because it is spread before getting sent to globby:

https://github.com/segmentio/dependency-report/blob/79c687eaa368a0d639d99251de217eda147a9325/lib/dependency-report.js#L35

Fixes #11.